### PR TITLE
feat: Write out emojis to system instead of copying

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,1 @@
-- Make it so that emoji is not copied, instead, it is directly pasted (without copying the emoji)
 - Make emoji search more accurate (get a better JSON file)

--- a/main.js
+++ b/main.js
@@ -3,8 +3,10 @@ const {
     BrowserWindow,
     Tray,
     globalShortcut,
-    Menu
+    Menu,
+    ipcMain
 } = require('electron')
+const robot = require('robotjs');
 
 // This is the npm package `open`, it is used here to open all links in an external browser
 const open = require('open')
@@ -49,7 +51,8 @@ const createWindow = () => {
         alwaysOnTop: true,
         webPreferences: {
             backgroundThrottling: false,
-            nodeIntegration: true
+            nodeIntegration: true,
+            contextIsolation: false
         }
     })
 
@@ -94,6 +97,12 @@ const createWindow = () => {
         window.setSkipTaskbar(true)
     }
 }
+
+// When we get a signal to type an emoji, use RobotJS to type it out
+ipcMain.on('typeEmoji', (_event, arg) => {
+    hideWindow();
+    robot.typeString(arg);
+});
 
 const toggleWindow = () => {
     if (window.isVisible()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,13 +34,13 @@
             }
         },
         "@types/node": {
-            "version": "14.17.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
-            "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw=="
+            "version": "14.17.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.4.tgz",
+            "integrity": "sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A=="
         },
         "ansi-regex": {
             "version": "2.1.1",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
@@ -85,9 +85,9 @@
             }
         },
         "boolean": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.0.tgz",
-            "integrity": "sha512-K6r5tvO1ykeYerI7jIyTvSFw2l6D6DzqkljGj2E2uyYAAdDo2SV4qGJIV75cHIQpTFyb6BB0BEHiDdDrFsNI+g==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.2.tgz",
+            "integrity": "sha512-YN6UmV0FfLlBVvRvNPx3pz5W/mUoYB24J4WSXOKP/OOJpi+Oq6WYqPaNTHzjI0QzwWtnvEd5CGYyQPgp1jFxnw==",
             "optional": true
         },
         "buffer": {
@@ -153,7 +153,7 @@
         },
         "code-point-at": {
             "version": "1.1.0",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/code-point-at/-/code-point-at-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-stream": {
@@ -179,13 +179,13 @@
         },
         "console-control-strings": {
             "version": "1.1.0",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-js": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.14.0.tgz",
-            "integrity": "sha512-3s+ed8er9ahK+zJpp9ZtuVcDoFzHNiZsPbNAAE4KXgrRHbjSqqNN6xGSXq6bq7TZIbKj4NLrLb6bJ5i+vSVjHA==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
+            "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==",
             "optional": true
         },
         "core-util-is": {
@@ -194,9 +194,9 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "requires": {
                 "ms": "2.1.2"
             }
@@ -235,12 +235,12 @@
         },
         "delegates": {
             "version": "1.0.0",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/delegates/-/delegates-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
         },
         "detect-libc": {
             "version": "1.0.3",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/detect-libc/-/detect-libc-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
         },
         "detect-node": {
@@ -255,9 +255,9 @@
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
         },
         "electron": {
-            "version": "12.0.10",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.10.tgz",
-            "integrity": "sha512-qaNvFG4AgeuT3PkSljQ9MlY7hz87wIwJ5cmSZ1453IVsUd0BV7pcaLViSpR1bRSqxetDDWxCLtCp0N9RXeDZww==",
+            "version": "12.0.13",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.13.tgz",
+            "integrity": "sha512-2yx102mhqgyaTVH+GCet4hURKOIuI27DcVdlval5T3eOEZMOHNrCbi8/8PZ7MqMfB5PIxJ+grS5S00/n5Zcu2Q==",
             "requires": {
                 "@electron/get": "^1.0.1",
                 "@types/node": "^14.6.2",
@@ -449,7 +449,7 @@
         },
         "has-unicode": {
             "version": "2.0.1",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-unicode/-/has-unicode-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "http-cache-semantics": {
@@ -479,7 +479,7 @@
         },
         "is-fullwidth-code-point": {
             "version": "1.0.0",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "requires": {
                 "number-is-nan": "^1.0.0"
@@ -640,12 +640,12 @@
         },
         "number-is-nan": {
             "version": "1.0.1",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
             "version": "4.1.1",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/object-assign/-/object-assign-4.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-keys": {
@@ -663,9 +663,9 @@
             }
         },
         "open": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.2.0.tgz",
-            "integrity": "sha512-O8uInONB4asyY3qUcEytpgwxQG3O0fJ/hlssoUHsBboOIRVZzT6Wq+Rwj5nffbeUhOdMjpXeISpDDzHCMRDuOQ==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.2.1.tgz",
+            "integrity": "sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==",
             "requires": {
                 "define-lazy-prop": "^2.0.0",
                 "is-docker": "^2.1.1",
@@ -824,7 +824,7 @@
         },
         "set-blocking": {
             "version": "2.0.0",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "signal-exit": {
@@ -870,7 +870,7 @@
         },
         "string-width": {
             "version": "1.0.2",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "requires": {
                 "code-point-at": "^1.0.0",
@@ -888,7 +888,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
                 "ansi-regex": "^2.0.0"
@@ -896,7 +896,7 @@
         },
         "strip-json-comments": {
             "version": "2.0.1",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "sumchecker": {
@@ -955,7 +955,7 @@
         },
         "tunnel-agent": {
             "version": "0.6.0",
-            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
                 "safe-buffer": "^5.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,869 +1,8 @@
 {
     "name": "geniemoji",
     "version": "4.0.0",
-    "lockfileVersion": 2,
+    "lockfileVersion": 1,
     "requires": true,
-    "packages": {
-        "": {
-            "name": "geniemoji",
-            "version": "4.0.0",
-            "license": "MIT",
-            "dependencies": {
-                "electron": "^12.0.4",
-                "open": "^8.0.9"
-            }
-        },
-        "node_modules/@electron/get": {
-            "version": "1.12.4",
-            "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.4.tgz",
-            "integrity": "sha512-6nr9DbJPUR9Xujw6zD3y+rS95TyItEVM0NVjt1EehY2vUWfIgPiIPVHxCvaTS0xr2B+DRxovYVKbuOWqC35kjg==",
-            "dependencies": {
-                "debug": "^4.1.1",
-                "env-paths": "^2.2.0",
-                "fs-extra": "^8.1.0",
-                "got": "^9.6.0",
-                "progress": "^2.0.3",
-                "semver": "^6.2.0",
-                "sumchecker": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            },
-            "optionalDependencies": {
-                "global-agent": "^2.0.2",
-                "global-tunnel-ng": "^2.7.1"
-            }
-        },
-        "node_modules/@sindresorhus/is": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-            "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@szmarczak/http-timer": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-            "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-            "dependencies": {
-                "defer-to-connect": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@types/node": {
-            "version": "14.17.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
-            "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw=="
-        },
-        "node_modules/boolean": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.0.tgz",
-            "integrity": "sha512-K6r5tvO1ykeYerI7jIyTvSFw2l6D6DzqkljGj2E2uyYAAdDo2SV4qGJIV75cHIQpTFyb6BB0BEHiDdDrFsNI+g==",
-            "optional": true
-        },
-        "node_modules/buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/buffer-from": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-        },
-        "node_modules/cacheable-request": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-            "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-            "dependencies": {
-                "clone-response": "^1.0.2",
-                "get-stream": "^5.1.0",
-                "http-cache-semantics": "^4.0.0",
-                "keyv": "^3.0.0",
-                "lowercase-keys": "^2.0.0",
-                "normalize-url": "^4.1.0",
-                "responselike": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/lowercase-keys": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-            "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/clone-response": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-            "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-            "dependencies": {
-                "mimic-response": "^1.0.0"
-            }
-        },
-        "node_modules/concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "engines": [
-                "node >= 0.8"
-            ],
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-            }
-        },
-        "node_modules/config-chain": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
-            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-            "optional": true,
-            "dependencies": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
-            }
-        },
-        "node_modules/core-js": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.14.0.tgz",
-            "integrity": "sha512-3s+ed8er9ahK+zJpp9ZtuVcDoFzHNiZsPbNAAE4KXgrRHbjSqqNN6xGSXq6bq7TZIbKj4NLrLb6bJ5i+vSVjHA==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "node_modules/debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/decompress-response": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-            "dependencies": {
-                "mimic-response": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/defer-to-connect": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-            "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
-        },
-        "node_modules/define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/define-properties": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "optional": true,
-            "dependencies": {
-                "object-keys": "^1.0.12"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/detect-node": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-            "optional": true
-        },
-        "node_modules/duplexer3": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-        },
-        "node_modules/electron": {
-            "version": "12.0.10",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.10.tgz",
-            "integrity": "sha512-qaNvFG4AgeuT3PkSljQ9MlY7hz87wIwJ5cmSZ1453IVsUd0BV7pcaLViSpR1bRSqxetDDWxCLtCp0N9RXeDZww==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "@electron/get": "^1.0.1",
-                "@types/node": "^14.6.2",
-                "extract-zip": "^1.0.3"
-            },
-            "bin": {
-                "electron": "cli.js"
-            },
-            "engines": {
-                "node": ">= 8.6"
-            }
-        },
-        "node_modules/encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-            "optional": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "dependencies": {
-                "once": "^1.4.0"
-            }
-        },
-        "node_modules/env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/es6-error": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-            "optional": true
-        },
-        "node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "optional": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/extract-zip": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-            "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
-            "dependencies": {
-                "concat-stream": "^1.6.2",
-                "debug": "^2.6.9",
-                "mkdirp": "^0.5.4",
-                "yauzl": "^2.10.0"
-            },
-            "bin": {
-                "extract-zip": "cli.js"
-            }
-        },
-        "node_modules/extract-zip/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/extract-zip/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "node_modules/fd-slicer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-            "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-            "dependencies": {
-                "pend": "~1.2.0"
-            }
-        },
-        "node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/get-stream": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/global-agent": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.2.0.tgz",
-            "integrity": "sha512-+20KpaW6DDLqhG7JDiJpD1JvNvb8ts+TNl7BPOYcURqCrXqnN1Vf+XVOrkKJAFPqfX+oEhsdzOj1hLWkBTdNJg==",
-            "optional": true,
-            "dependencies": {
-                "boolean": "^3.0.1",
-                "core-js": "^3.6.5",
-                "es6-error": "^4.1.1",
-                "matcher": "^3.0.0",
-                "roarr": "^2.15.3",
-                "semver": "^7.3.2",
-                "serialize-error": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=10.0"
-            }
-        },
-        "node_modules/global-agent/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "optional": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/global-tunnel-ng": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz",
-            "integrity": "sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==",
-            "optional": true,
-            "dependencies": {
-                "encodeurl": "^1.0.2",
-                "lodash": "^4.17.10",
-                "npm-conf": "^1.1.3",
-                "tunnel": "^0.0.6"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/globalthis": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
-            "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
-            "optional": true,
-            "dependencies": {
-                "define-properties": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/got": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-            "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-            "dependencies": {
-                "@sindresorhus/is": "^0.14.0",
-                "@szmarczak/http-timer": "^1.1.2",
-                "cacheable-request": "^6.0.0",
-                "decompress-response": "^3.3.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^4.1.0",
-                "lowercase-keys": "^1.0.1",
-                "mimic-response": "^1.0.1",
-                "p-cancelable": "^1.0.0",
-                "to-readable-stream": "^1.0.0",
-                "url-parse-lax": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
-        "node_modules/graceful-fs": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
-        },
-        "node_modules/http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "node_modules/ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "optional": true
-        },
-        "node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "node_modules/json-buffer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-            "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-        },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-            "optional": true
-        },
-        "node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/keyv": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-            "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-            "dependencies": {
-                "json-buffer": "3.0.0"
-            }
-        },
-        "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "optional": true
-        },
-        "node_modules/lowercase-keys": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "optional": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/matcher": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-            "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-            "optional": true,
-            "dependencies": {
-                "escape-string-regexp": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/mimic-response": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
-        "node_modules/mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-            "dependencies": {
-                "minimist": "^1.2.5"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
-        "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node_modules/normalize-url": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-            "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/npm-conf": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
-            "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
-            "optional": true,
-            "dependencies": {
-                "config-chain": "^1.1.11",
-                "pify": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/object-keys": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "optional": true,
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
-        "node_modules/open": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.2.0.tgz",
-            "integrity": "sha512-O8uInONB4asyY3qUcEytpgwxQG3O0fJ/hlssoUHsBboOIRVZzT6Wq+Rwj5nffbeUhOdMjpXeISpDDzHCMRDuOQ==",
-            "dependencies": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-cancelable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-            "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/pend": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
-        },
-        "node_modules/pify": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-            "optional": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/prepend-http": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-            "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-        },
-        "node_modules/progress": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/proto-list": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-            "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-            "optional": true
-        },
-        "node_modules/pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
-        "node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/responselike": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-            "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-            "dependencies": {
-                "lowercase-keys": "^1.0.0"
-            }
-        },
-        "node_modules/roarr": {
-            "version": "2.15.4",
-            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-            "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-            "optional": true,
-            "dependencies": {
-                "boolean": "^3.0.1",
-                "detect-node": "^2.0.4",
-                "globalthis": "^1.0.1",
-                "json-stringify-safe": "^5.0.1",
-                "semver-compare": "^1.0.0",
-                "sprintf-js": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
-        "node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/semver-compare": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-            "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-            "optional": true
-        },
-        "node_modules/serialize-error": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-            "optional": true,
-            "dependencies": {
-                "type-fest": "^0.13.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-            "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-            "optional": true
-        },
-        "node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/sumchecker": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
-            "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
-            "dependencies": {
-                "debug": "^4.1.0"
-            },
-            "engines": {
-                "node": ">= 8.0"
-            }
-        },
-        "node_modules/to-readable-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-            "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/tunnel": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-            "optional": true,
-            "engines": {
-                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-            }
-        },
-        "node_modules/type-fest": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-            "optional": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-        },
-        "node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
-        "node_modules/url-parse-lax": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-            "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-            "dependencies": {
-                "prepend-http": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "optional": true
-        },
-        "node_modules/yauzl": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-            "dependencies": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.1.0"
-            }
-        }
-    },
     "dependencies": {
         "@electron/get": {
             "version": "1.12.4",
@@ -899,11 +38,66 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
             "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw=="
         },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "aproba": {
+            "version": "1.2.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
+        },
+        "are-we-there-yet": {
+            "version": "1.1.5",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+            "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
+            "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+            }
+        },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo="
+        },
+        "bl": {
+            "version": "4.1.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha1-RRU1JkGCvsL7vIOmKrmM8R2fezo=",
+            "requires": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://eis.jfrog.io/eis/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
         "boolean": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.0.tgz",
             "integrity": "sha512-K6r5tvO1ykeYerI7jIyTvSFw2l6D6DzqkljGj2E2uyYAAdDo2SV4qGJIV75cHIQpTFyb6BB0BEHiDdDrFsNI+g==",
             "optional": true
+        },
+        "buffer": {
+            "version": "5.7.1",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=",
+            "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
         },
         "buffer-crc32": {
             "version": "0.2.13",
@@ -944,6 +138,11 @@
                 }
             }
         },
+        "chownr": {
+            "version": "1.1.4",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs="
+        },
         "clone-response": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -951,6 +150,11 @@
             "requires": {
                 "mimic-response": "^1.0.0"
             }
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-stream": {
             "version": "1.6.2",
@@ -972,6 +176,11 @@
                 "ini": "^1.3.4",
                 "proto-list": "~1.2.1"
             }
+        },
+        "console-control-strings": {
+            "version": "1.1.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-js": {
             "version": "3.14.0",
@@ -1000,6 +209,11 @@
                 "mimic-response": "^1.0.0"
             }
         },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
+        },
         "defer-to-connect": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
@@ -1018,6 +232,16 @@
             "requires": {
                 "object-keys": "^1.0.12"
             }
+        },
+        "delegates": {
+            "version": "1.0.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+        },
+        "detect-libc": {
+            "version": "1.0.3",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/detect-libc/-/detect-libc-1.0.3.tgz",
+            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
         },
         "detect-node": {
             "version": "2.1.0",
@@ -1071,6 +295,11 @@
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "optional": true
         },
+        "expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha1-bhSz/O4POmNA7LV9LokYaSBSpHw="
+        },
         "extract-zip": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
@@ -1105,6 +334,11 @@
                 "pend": "~1.2.0"
             }
         },
+        "fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
+        },
         "fs-extra": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -1115,6 +349,21 @@
                 "universalify": "^0.1.0"
             }
         },
+        "gauge": {
+            "version": "2.7.4",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/gauge/-/gauge-2.7.4.tgz",
+            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+            }
+        },
         "get-stream": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -1122,6 +371,11 @@
             "requires": {
                 "pump": "^3.0.0"
             }
+        },
+        "github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
         },
         "global-agent": {
             "version": "2.2.0",
@@ -1193,10 +447,20 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
         },
+        "has-unicode": {
+            "version": "2.0.1",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-unicode/-/has-unicode-2.0.1.tgz",
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+        },
         "http-cache-semantics": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
             "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+        },
+        "ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I="
         },
         "inherits": {
             "version": "2.0.4",
@@ -1206,13 +470,20 @@
         "ini": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "optional": true
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
         "is-docker": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
             "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
         },
         "is-wsl": {
             "version": "2.2.0",
@@ -1301,10 +572,45 @@
                 "minimist": "^1.2.5"
             }
         },
+        "mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM="
+        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "nan": {
+            "version": "2.14.2",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk="
+        },
+        "napi-build-utils": {
+            "version": "1.0.2",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+            "integrity": "sha1-sf3cCyxG44Cgt6dvmE3UfEGhOAY="
+        },
+        "node-abi": {
+            "version": "2.30.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/node-abi/-/node-abi-2.30.0.tgz",
+            "integrity": "sha1-i+U78+eUWjTuoQ4PyaWYJ3bPVQs=",
+            "requires": {
+                "semver": "^5.4.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://eis.jfrog.io/eis/api/npm/npm/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+                }
+            }
+        },
+        "noop-logger": {
+            "version": "0.1.1",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/noop-logger/-/noop-logger-0.1.1.tgz",
+            "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
         },
         "normalize-url": {
             "version": "4.5.1",
@@ -1320,6 +626,27 @@
                 "config-chain": "^1.1.11",
                 "pify": "^3.0.0"
             }
+        },
+        "npmlog": {
+            "version": "4.1.2",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/npmlog/-/npmlog-4.1.2.tgz",
+            "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+            "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-keys": {
             "version": "1.1.1",
@@ -1361,6 +688,28 @@
             "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
             "optional": true
         },
+        "prebuild-install": {
+            "version": "5.3.6",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/prebuild-install/-/prebuild-install-5.3.6.tgz",
+            "integrity": "sha1-fCJVaNhkxx2J0H+HlgQnM6P1QpE=",
+            "requires": {
+                "detect-libc": "^1.0.3",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.3",
+                "mkdirp-classic": "^0.5.3",
+                "napi-build-utils": "^1.0.1",
+                "node-abi": "^2.7.0",
+                "noop-logger": "^0.1.1",
+                "npmlog": "^4.0.1",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^3.0.3",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0",
+                "which-pm-runs": "^1.0.0"
+            }
+        },
         "prepend-http": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
@@ -1389,6 +738,17 @@
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
+            }
+        },
+        "rc": {
+            "version": "1.2.8",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
+            "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             }
         },
         "readable-stream": {
@@ -1427,6 +787,16 @@
                 "sprintf-js": "^1.1.2"
             }
         },
+        "robotjs": {
+            "version": "0.6.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/robotjs/-/robotjs-0.6.0.tgz",
+            "integrity": "sha1-jR9jIh9bGNxJbHdo91JhBDiR9ko=",
+            "requires": {
+                "nan": "^2.14.0",
+                "node-abi": "^2.13.0",
+                "prebuild-install": "^5.3.3"
+            }
+        },
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -1452,11 +822,61 @@
                 "type-fest": "^0.13.1"
             }
         },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
+        "signal-exit": {
+            "version": "3.0.3",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/signal-exit/-/signal-exit-3.0.3.tgz",
+            "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw="
+        },
+        "simple-concat": {
+            "version": "1.0.1",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha1-9Gl2CCujXCJj8cirXt/ibEHJVS8="
+        },
+        "simple-get": {
+            "version": "3.1.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/simple-get/-/simple-get-3.1.0.tgz",
+            "integrity": "sha1-tFvgYkNeUNFZVAtXYgLO7EC5xrM=",
+            "requires": {
+                "decompress-response": "^4.2.0",
+                "once": "^1.3.1",
+                "simple-concat": "^1.0.0"
+            },
+            "dependencies": {
+                "decompress-response": {
+                    "version": "4.2.1",
+                    "resolved": "https://eis.jfrog.io/eis/api/npm/npm/decompress-response/-/decompress-response-4.2.1.tgz",
+                    "integrity": "sha1-QUAjzHowLaJc4uyC0NUjjMr9iYY=",
+                    "requires": {
+                        "mimic-response": "^2.0.0"
+                    }
+                },
+                "mimic-response": {
+                    "version": "2.1.0",
+                    "resolved": "https://eis.jfrog.io/eis/api/npm/npm/mimic-response/-/mimic-response-2.1.0.tgz",
+                    "integrity": "sha1-0Tdj019hPQnsN+uzC6wEacDuj0M="
+                }
+            }
+        },
         "sprintf-js": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
             "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
             "optional": true
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            }
         },
         "string_decoder": {
             "version": "1.1.1",
@@ -1466,12 +886,60 @@
                 "safe-buffer": "~5.1.0"
             }
         },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+        },
         "sumchecker": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
             "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
             "requires": {
                 "debug": "^4.1.0"
+            }
+        },
+        "tar-fs": {
+            "version": "2.1.1",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/tar-fs/-/tar-fs-2.1.1.tgz",
+            "integrity": "sha1-SJoVq4Xx8L76uzcLfeT561y+h4Q=",
+            "requires": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha1-rK2EwoQTawYNw/qmRHSqmuvXcoc=",
+            "requires": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://eis.jfrog.io/eis/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
             }
         },
         "to-readable-stream": {
@@ -1484,6 +952,14 @@
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
             "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
             "optional": true
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
         },
         "type-fest": {
             "version": "0.13.1",
@@ -1513,6 +989,19 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "which-pm-runs": {
+            "version": "1.0.0",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+            "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+        },
+        "wide-align": {
+            "version": "1.1.3",
+            "resolved": "https://eis.jfrog.io/eis/api/npm/npm/wide-align/-/wide-align-1.1.3.tgz",
+            "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+            "requires": {
+                "string-width": "^1.0.2 || 2"
+            }
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "homepage": "https://github.com/virejdasani/Emojenie#readme",
     "dependencies": {
         "electron": "^12.0.4",
-        "open": "^8.0.9"
+        "open": "^8.0.9",
+        "robotjs": "^0.6.0"
     }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,8 @@
                     Use 'Control + E' to summon Geniemoji</br></br>
                     Navigation:</br>
                     Use Arrow Keys to go up and down</br>
-                    Press Enter to type the Emoji
+                    Press Enter to type the Emoji,
+                    Press Shift + Enter to copy the Emoji
                 </div>
             </div>
         </form>

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
                     Use 'Control + E' to summon Geniemoji</br></br>
                     Navigation:</br>
                     Use Arrow Keys to go up and down</br>
-                    Press Enter to copy the Emoji
+                    Press Enter to type the Emoji
                 </div>
             </div>
         </form>

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 var appVersion = "4.0.0"
 
+const electron = window.require('electron');
+
 // Whenever a letter is entered into the commandInput field, the search() function is executed. With this, matching emojis are displayed as the user is typing
 document.getElementById('commandInput').addEventListener('keyup', search)
 
@@ -39,7 +41,7 @@ function search() {
             currentEmojiLength = i
             // All the matching emojis are appended into answerEmojis. the '.char' is from the emoji.js file
             answerEmojis += `
-                <button type="button" onclick="copy('${item.char}')" class="emojiButton" tabindex="${i + 2}">
+                <button type="button" onclick="typeEmoji('${item.char}')" class="emojiButton" tabindex="${i + 2}">
                     ${item.char}
                     ${item.name}
                 </button>
@@ -72,22 +74,8 @@ document.getElementById('commandInput').addEventListener('keydown', (e) => {
 })
 
 // This is executed when an emoji button is pressed
-function copy(text) {
-    // To copy, a text area is created, the emojiChar is added to the text area. This is then selected and copied. After it is copied, the text area is deleted
-    var textarea = document.createElement("textarea")
-    textarea.value = text
-    document.body.appendChild(textarea)
-    textarea.select()
-    document.execCommand("copy")
-    document.body.removeChild(textarea)
-    document.getElementById('answer').innerHTML = `
-        <div id="info">
-            Copied emoji to clipboard!</br></br>
-            Press Escape to close this window</br></br>
-            <a href="https://virejdasani.github.io/Geniemoji/" target="_blank">Geniemoji</a> (${appVersion})</br>
-            Developed by <a href="https://virejdasani.github.io/virej/" target="_blank">Virej Dasani</a>
-        </div>
-    `
+function typeEmoji(text) {
+    electron.ipcRenderer.send('typeEmoji', text);
 }
 
 // For arrow key navigation

--- a/src/index.js
+++ b/src/index.js
@@ -41,13 +41,13 @@ function search() {
             currentEmojiLength = i
             // All the matching emojis are appended into answerEmojis. the '.char' is from the emoji.js file
             answerEmojis += `
-                <button type="button" onclick="typeEmoji('${item.char}')" class="emojiButton" tabindex="${i + 2}">
+                <button type="button" onclick="typeEmoji(event, '${item.char}')" class="emojiButton" tabindex="${i + 2}">
                     ${item.char}
                     ${item.name}
                 </button>
                 </br>
             ` // item.char is the emoji and item.name is the emoji name, both from the emojis.js file
-    })
+        })
 
     // If there are no matching emojis, it returns undefined. To not display 'undefined', we do the following
     if (typeof (answerEmojis) !== 'string') {
@@ -74,8 +74,33 @@ document.getElementById('commandInput').addEventListener('keydown', (e) => {
 })
 
 // This is executed when an emoji button is pressed
-function typeEmoji(text) {
-    electron.ipcRenderer.send('typeEmoji', text);
+function typeEmoji(event, text) {
+    if (event.shiftKey) {
+        // User held down Shift key while selecting this emoji, let's copy it
+        copy(text);
+    } else {
+        // User selected emoji with no Shift key, type out selected emoji
+        electron.ipcRenderer.send('typeEmoji', text)
+    }
+}
+
+// Function to copy text to clipboard
+function copy(text) {
+    // To copy, a text area is created, the emojiChar is added to the text area. This is then selected and copied. After it is copied, the text area is deleted
+    var textarea = document.createElement("textarea")
+    textarea.value = text
+    document.body.appendChild(textarea)
+    textarea.select()
+    document.execCommand("copy")
+    document.body.removeChild(textarea)
+    document.getElementById('answer').innerHTML = `
+        <div id="info">
+            Copied emoji to clipboard!</br></br>
+            Press Escape to close this window</br></br>
+            <a href="https://virejdasani.github.io/Geniemoji/" target="_blank">Geniemoji</a> (${appVersion})</br>
+            Developed by <a href="https://virejdasani.github.io/virej/" target="_blank">Virej Dasani</a>
+        </div>
+    `
 }
 
 // For arrow key navigation
@@ -90,7 +115,7 @@ document.addEventListener("keydown", (event) => {
         // circle through emojis
         // ArrowUp and focus on input field? -> select last emoji
         if (tabIndex < 1) {
-            tabIndex = currentEmojiLength + 2   // '+2': tabIndex starts with 1, 1 = input
+            tabIndex = currentEmojiLength + 2 // '+2': tabIndex starts with 1, 1 = input
         }
         // ArrowDown and focus on last emoji? -> select input field
         if (tabIndex > currentEmojiLength + 2) {


### PR DESCRIPTION
This addresses feature request #6. 

- Brought in RobotJS
- Refactored main functionality so that when a user clicks or hits 'enter' on a specific emoji, it will immediately close the window and type out the selected emoji to the system

This is a major chance of functionality so I will leave it to @virejdasani if they want Geniemoji to go in this direction. 

Note that RobotJS seems to require explicit permissions on macOS. When the user first will run this application, a pop up will appear that will require them to give Geniemoji permissions in order to type on the user's behalf. See below images: 
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1024355/123119784-d2bbfd00-d411-11eb-862c-0e478a210346.png">
<img width="780" alt="image" src="https://user-images.githubusercontent.com/1024355/123119806-d780b100-d411-11eb-8b87-c0024426a1b3.png">

See functionality in action below: 
![Geniemoji with keys](https://user-images.githubusercontent.com/1024355/123119909-e8312700-d411-11eb-9c26-5e411f292a0b.gif)
